### PR TITLE
Base Workspace on host Solution

### DIFF
--- a/ColorizedTextFactoryAdHocTests.cs
+++ b/ColorizedTextFactoryAdHocTests.cs
@@ -18,24 +18,54 @@ namespace SnippetColorizer
         }
 
         [STAThread]
-        void ShowTextViewHost()
+        void ShowTextView_ExistingFile()
         {
-            var source = GetSource();
-            var host = colorizedTextFactory.CreateTextViewHost(source, "CSharp");
-            var window = new Window { Content = host.HostControl };
-            window.ShowDialog();
-        }
-
-        [STAThread]
-        void ShowTextView()
-        {
-            var source = GetSource();
-            var view = colorizedTextFactory.CreateTextView(source, "CSharp");
+            var fileName = GetFileName();
+            var source = File.ReadAllText(fileName);
+            var view = colorizedTextFactory.CreateTextView(source, fileName, "CSharp");
             var window = new Window { Content = view };
             window.ShowDialog();
         }
 
-        static string GetSource() =>
-            File.ReadAllText(new StackFrame(true).GetFileName());
+        [STAThread]
+        void ShowTextView_ReplacementFile()
+        {
+            var fileName = GetFileName();
+            var view = colorizedTextFactory.CreateTextView(ExampleSource, fileName, "CSharp");
+            var window = new Window { Content = view };
+            window.ShowDialog();
+        }
+
+        [STAThread]
+        void ShowTextView_NewFile()
+        {
+            var fileName = @"c:\new.cs";
+            var view = colorizedTextFactory.CreateTextView(ExampleSource, fileName, "CSharp");
+            var window = new Window { Content = view };
+            window.ShowDialog();
+        }
+
+        [STAThread]
+        void ShowTextViewHost_ExistingFile()
+        {
+            var fileName = GetFileName();
+            var source = File.ReadAllText(fileName);
+            var host = colorizedTextFactory.CreateTextViewHost(source, fileName, "CSharp");
+            var window = new Window { Content = host.HostControl };
+            window.ShowDialog();
+        }
+
+        static string GetFileName() => new StackFrame(true).GetFileName();
+
+        static string ExampleSource =>
+@"using System.Windows;
+
+class Foo
+{
+    void Bar()
+    {
+        new Window { Content = ""Hello, World"" }.ShowDialog();
+    }
+}";
     }
 }


### PR DESCRIPTION
### What this PR does

This PR lets you view a "satellite" source file that knows about and can use symbols from the active solution.

For example, the following test demonstrates viewing some `ExampleSource` in place of the source file at `fileName`.

https://github.com/jcansdale/SnippetColorizer/blob/9da8f9fc65c927c205af5e1c8f462c3baad41fae/ColorizedTextFactoryAdHocTests.cs#L30-L37

Below you can see the `Window` symbol is active in the `TextView`. This indicates that the snippet can see the `PresentationFramework` assembly. The symbol appears because `PresentationFramework` is referenced by the project that contains `fileName` which `ExampleSource` is replacing.

![image](https://user-images.githubusercontent.com/11719160/48256180-bc9ad300-e406-11e8-9fd6-f4540b726d1f.png)
